### PR TITLE
VBXE vs. cart loading fix

### DIFF
--- a/Atari800.sv
+++ b/Atari800.sv
@@ -492,8 +492,8 @@ assign CLK_VIDEO = clk_vdo;
 wire cpu_halt;
 
 wire [15:0] laudio, raudio;
-assign AUDIO_L = {laudio[15],laudio[15:1]};
-assign AUDIO_R = status[20] ? {raudio[15],raudio[15:1]} : AUDIO_L;
+assign AUDIO_L = cpu_halt ? 16'b0000000000000000 : {laudio[15],laudio[15:1]};
+assign AUDIO_R = cpu_halt ? 16'b0000000000000000 : (status[20] ? {raudio[15],raudio[15:1]} : AUDIO_L);
 assign AUDIO_S = 1;
 assign AUDIO_MIX = status[4:3];
 
@@ -537,6 +537,7 @@ atari800top atari800top
 	.UPLOAD_READY(upload_ready),
 	.SDRAM_READY(sdram_ready),
 	.INIT_HOLD(init_hold),
+	.OSD_PAUSE(ioctl_download),
 
 	.PAL(pal_video),
 	.EXT_ANTIC(status[33]),

--- a/rtl/atari800top.vhd
+++ b/rtl/atari800top.vhd
@@ -58,6 +58,7 @@ PORT
 	UPLOAD_DATA : in std_logic_vector(7 downto 0);
 	UPLOAD_READY : out std_logic;
 	INIT_HOLD : in std_logic;
+	OSD_PAUSE : in std_logic;
 	SDRAM_READY : out std_logic;
 
 	PS2_KEY    : IN  STD_LOGIC_VECTOR(10 downto 0);
@@ -535,7 +536,7 @@ PORT MAP
 	ZPU_OUT3 => zpu_out3
 );
 
-pause_atari <= zpu_out1(0) or INIT_HOLD;
+pause_atari <= zpu_out1(0) or INIT_HOLD or OSD_PAUSE;
 reset_atari <= zpu_out1(1);
 emulated_cartridge2_select <= zpu_out1(16 downto 9);
 emulated_cartridge_select <= zpu_out1(24 downto 17);


### PR DESCRIPTION
This fixes a problem when the cart is loaded from OSD and the Atari has VBXE (its memac to be more precise) running, this was resulting in a total device lock up. It also makes it nice for the ears during any core pausing (the sound is not suspended ugly). 

(I still didn't get to figuring out the master and VBXE branch merge with conditional compilation, all kinds of things get in the way...)